### PR TITLE
- Change the command to install vault chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main
 deploy vault with helm
 ```
 helm repo add hashicorp https://helm.releases.hashicorp.com
-helm install vault hashicorp/vault
+helm install vault hashicorp/vault --version 0.19.0
 ```
 set the vault ingress
 ```


### PR DESCRIPTION
Fixed the command to install previous version of vault chart.

Original command: 

```shell
helm install vault hashicorp/vault
```
Error:
```
Error: parse error at (vault/templates/_helpers.tpl:38): unclosed action
```